### PR TITLE
 Add features debug log output disabled when startup params without v.

### DIFF
--- a/lyrebird/manager.py
+++ b/lyrebird/manager.py
@@ -45,7 +45,6 @@ class Server:
         self.proxy_server = None
         self._conf_manager = None
         self.pid_file_name = None
-        init_logger_settings()
 
     def v(self):
         """
@@ -113,6 +112,7 @@ class Server:
 
         :return: 
         """
+        init_logger_settings(verbose=self.verbose)
         self.init_conf()
         self.mock_server = mock_server.LyrebirdMockServer(self._conf, self.verbose)
         self.mock_server.start()

--- a/lyrebird/mock/logger_config.py
+++ b/lyrebird/mock/logger_config.py
@@ -1,4 +1,4 @@
-import os, codecs, shutil
+import codecs
 import configparser
 from pathlib import Path
 
@@ -23,9 +23,9 @@ class LoggingConfig:
     LOGGING_CONFIG = 'logging_config.ini'
     USER_LOGGING_CONFIG = USER_ROOT / LOGGING_CONFIG
 
-    def __init__(self):
+    def __init__(self, verbose):
         self.init_log_dir()
-        self.init_logger_config()
+        self.verbose = verbose
 
     def init_log_dir(self):
         """
@@ -35,6 +35,9 @@ class LoggingConfig:
         :return:
         """
         self.LOGFILE_PATH.mkdir(parents=True, exist_ok=True)
+
+    def get_level(self):
+        return "DEBUG" if self.verbose else "INFO"
 
     def init_logger_config(self):
         if self.USER_LOGGING_CONFIG.exists():
@@ -55,6 +58,7 @@ class LoggingConfig:
                     logger_options=option,
                     logger_value=user_conf.get(section, option)
                 )
+        set_logger_config(default_conf, logger_section='handler_stream', logger_options='level', logger_value=self.get_level())
         with codecs.open(self.USER_LOGGING_CONFIG, 'w', 'utf-8') as f:
             default_conf.write(f)
 
@@ -67,11 +71,14 @@ class LoggingConfig:
             logger_options='args',
             logger_value='("%s", "midnight", 1, 5, "utf-8")' % (self.USER_ROOT / 'log' / 'lyrebird.log')
         )
+        set_logger_config(conf, logger_section='handler_stream', logger_options='level', logger_value=self.get_level())
         with codecs.open(self.USER_LOGGING_CONFIG, 'w', 'utf-8') as f:
             conf.write(f)
 
     def get_user_logging_config(self):
+        self.init_logger_config()
         return self.USER_ROOT / self.LOGGING_CONFIG
 
-
-loggingConfig = LoggingConfig()
+    def use_default_logging_config(self):
+        self.create_logger_config()
+        return self.USER_ROOT / self.LOGGING_CONFIG

--- a/lyrebird/mock/logger_config.py
+++ b/lyrebird/mock/logger_config.py
@@ -37,6 +37,12 @@ class LoggingConfig:
         self.LOGFILE_PATH.mkdir(parents=True, exist_ok=True)
 
     def get_level(self):
+        """
+        启动参数带 v， 则 level 为 DEBUG
+        启动参数不带 v，则 level 为 INFO
+
+        :return: "DEBUG" or "INFO"
+        """
         return "DEBUG" if self.verbose else "INFO"
 
     def init_logger_config(self):
@@ -58,6 +64,7 @@ class LoggingConfig:
                     logger_options=option,
                     logger_value=user_conf.get(section, option)
                 )
+        # Update handler_stream - Level from start params <v>
         set_logger_config(default_conf, logger_section='handler_stream', logger_options='level', logger_value=self.get_level())
         with codecs.open(self.USER_LOGGING_CONFIG, 'w', 'utf-8') as f:
             default_conf.write(f)
@@ -71,6 +78,7 @@ class LoggingConfig:
             logger_options='args',
             logger_value='("%s", "midnight", 1, 5, "utf-8")' % (self.USER_ROOT / 'log' / 'lyrebird.log')
         )
+        # Update handler_stream - Level from start params <v>
         set_logger_config(conf, logger_section='handler_stream', logger_options='level', logger_value=self.get_level())
         with codecs.open(self.USER_LOGGING_CONFIG, 'w', 'utf-8') as f:
             conf.write(f)

--- a/lyrebird/mock/logger_helper.py
+++ b/lyrebird/mock/logger_helper.py
@@ -2,7 +2,7 @@ import logging
 import colorama
 import copy
 from logging.config import fileConfig
-from .logger_config import loggingConfig
+from .logger_config import LoggingConfig
 
 def _print_error(msg):
     print('\n!!!!!!!!!!!!!!!!!!!!!!!!\n!!!    %s\n!!!!!!!!!!!!!!!!!!!!!!!!\n' % msg)
@@ -37,9 +37,20 @@ LOG_COLORS = {
 }
 
 
-def init_logger_settings():
-    logging.config.fileConfig(loggingConfig.get_user_logging_config(),
-                              disable_existing_loggers=False)
+def init_logger_settings(*, verbose=False):
+    logging_config = LoggingConfig(verbose)
+    try:
+        logging.config.fileConfig(
+            logging_config.get_user_logging_config(),
+            disable_existing_loggers=False)
+    except SyntaxError:
+        '''
+        若获取用户 Logging 配置文件，更新的过程中出现无法解析异常
+        则 使用默认的配置加载
+        '''
+        logging.config.fileConfig(
+            logging_config.use_default_logging_config(),
+            disable_existing_loggers=False)
 
     socketio = logging.getLogger('socketio')
     socketio.setLevel(logging.ERROR)

--- a/lyrebird/templates/logging_config.ini
+++ b/lyrebird/templates/logging_config.ini
@@ -10,7 +10,7 @@ keys = stream, logFileHandler
 
 [handler_stream]
 class = StreamHandler
-level = DEBUG
+level = INFO
 formatter = stream
 args = ''
 


### PR DESCRIPTION
### FEATURES
- debug log output disabled when startup params without v.
- debug log output enabled when startup params with v.
- logging_config.ini can be loaded normally despite SyntaxError.