### PR TITLE
fix click version incompatible

### DIFF
--- a/lyrebird/version.py
+++ b/lyrebird/version.py
@@ -1,3 +1,3 @@
-IVERSION = (0, 13, 5)
+IVERSION = (0, 13, 6)
 VERSION = ".".join(str(i) for i in IVERSION)
 LYREBIRD = "Lyrebird " + VERSION

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
         ]
     },
     install_requires=[
-        'flask',
         'mitmproxy==4.0.4',
+        'flask',
         'requests',
         'fire',
         'colorama',


### PR DESCRIPTION
Fix: mitmproxy 4.0.4 has requirement click<7,>=6.2, but you'll have click 7.0 which is incompatible